### PR TITLE
Fixed Python3 support (xrange to range)

### DIFF
--- a/python/hvac_ircontrol/ir_sender.py
+++ b/python/hvac_ircontrol/ir_sender.py
@@ -310,7 +310,7 @@ class IrSender():
         self.__log(LogLevel.Minimal, "Sending data %s:" % ("inverted " if mustInvert else ""))
         self.__log(LogLevel.Minimal, (' '.join('{:x}'.format(d) for d in data)).upper())
         # Send all Bits from Byte Data in Reverse Order
-        for i in xrange(0, len(data)):
+        for i in range(0, len(data)):
             idx = i if mustInvert else (len(data) - i - 1)
             mask = 1
             while mask < maxMask and mask > 0:


### PR DESCRIPTION
In Python3 there's not xrange function, so I put the "range" function that does basically the same as xrange, but it's both Python2 and Python3 compatible.